### PR TITLE
Fix get_irq_status - must read 3 bytes

### DIFF
--- a/src/sx/mod.rs
+++ b/src/sx/mod.rs
@@ -386,10 +386,11 @@ where
 
     /// Get the current IRQ status
     pub fn get_irq_status(&mut self) -> Result<IrqStatus, SxError<TSPIERR, TPINERR>> {
-        let mut status = [NOP, NOP];
+        let mut status = [NOP, NOP, NOP];
         let mut ops = [Operation::Write(&[0x12]), Operation::Read(&mut status)];
         self.spi.transaction(&mut ops).map_err(SpiError::Transfer)?;
-        Ok(u16::from_be_bytes(status).into())
+        let irq_status: [u8; 2] = [status[1], status[2]];
+        Ok(u16::from_be_bytes(irq_status).into())
     }
 
     /// Clear the IRQ status


### PR DESCRIPTION
See the documentation for SX1262 here https://semtech.my.salesforce.com/sfc/p/E0000000JelG/a/2R000000Un7F/yT.fKdAr9ZAo3cJLc4F2cBdUsMftpT2vsOICP7NmvMo

```
13.3.3 GetIrqStatus
This command returns the value of the IRQ register.

Table 13-30: GetIrqStatus SPI Transaction
Byte           0             1      2-3
Data from host Opcode = 0x12 NOP    NOP
Data to host   RFU           Status IrqStatus(15:0)
```

The old code only reads two bytes and parses the Radio status + high byte of irq status, which gives wrong flags.

Fixes: #4 