### PR TITLE
async API using maybe-async-cfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,9 +21,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "maybe-async-cfg"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dbfaa67a76e2623580df07d6bb5e7956c0a4bae4b418314083a9c619bd66627"
+dependencies = [
+ "manyhow",
+ "proc-macro2",
+ "pulldown-cmark",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679341d22c78c6c649893cbd6c3278dcbe9fc4faa62fea3a9296ae2b50c14625"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "sx126x"
 version = "0.3.0"
 dependencies = [
  "critical-section",
  "embedded-hal",
+ "embedded-hal-async",
+ "maybe-async-cfg",
 ]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,14 @@ exclude = [
 
 [dependencies]
 embedded-hal = "1.0"
+embedded-hal-async = { version = "1.0", optional = true }
 critical-section = "^1"
+maybe-async-cfg = "0.2.5"
+
+[features]
+default = ["sync"]
+sync = []
+async = ["dep:embedded-hal-async"]
 
 [profile.dev]
 opt-level = 0

--- a/src/sx/mod.rs
+++ b/src/sx/mod.rs
@@ -1,10 +1,14 @@
 pub(crate) mod err;
 
 use core::convert::TryInto;
-use embedded_hal::digital::InputPin;
-use embedded_hal::digital::OutputPin;
-use embedded_hal::spi::Operation;
-use embedded_hal::spi::SpiDevice;
+
+use embedded_hal::{
+    digital::{InputPin, OutputPin},
+    spi::{Operation, SpiDevice},
+};
+#[cfg(feature = "async")]
+use embedded_hal_async::{digital::Wait, spi::SpiDevice as SpiDeviceAsync};
+
 use err::SpiError;
 
 use crate::conf::Config;
@@ -30,7 +34,8 @@ pub fn calc_rf_freq(rf_frequency: f32, f_xtal: f32) -> u32 {
 }
 
 /// Wrapper around a Semtech SX1261/62 LoRa modem
-pub struct SX126x<TSPI: SpiDevice, TNRST, TBUSY, TANT, TDIO1> {
+#[maybe_async_cfg::maybe(sync(feature = "sync", keep_self), async(feature = "async"))]
+pub struct SX126x<TSPI, TNRST, TBUSY, TANT, TDIO1> {
     spi: TSPI,
     nrst_pin: TNRST,
     busy_pin: TBUSY,
@@ -38,13 +43,21 @@ pub struct SX126x<TSPI: SpiDevice, TNRST, TBUSY, TANT, TDIO1> {
     dio1_pin: TDIO1,
 }
 
+#[maybe_async_cfg::maybe(
+    sync(feature = "sync", keep_self),
+    async(feature = "async"),
+    idents(
+        SpiDevice(sync, async = "SpiDeviceAsync"),
+        InputPin(sync, async = "Wait")
+    )
+)]
 impl<TSPI, TNRST, TBUSY, TANT, TDIO1, TSPIERR, TPINERR> SX126x<TSPI, TNRST, TBUSY, TANT, TDIO1>
 where
     TPINERR: core::fmt::Debug,
     TSPI: SpiDevice<Error = TSPIERR>,
     TNRST: OutputPin<Error = TPINERR>,
-    TBUSY: InputPin<Error = TPINERR>,
     TANT: OutputPin<Error = TPINERR>,
+    TBUSY: InputPin<Error = TPINERR>,
     TDIO1: InputPin<Error = TPINERR>,
 {
     // Create a new SX126x
@@ -59,58 +72,107 @@ where
         }
     }
 
+    /// Busily wait for the busy pin to go low
+    #[maybe_async_cfg::only_if(sync)]
+    pub fn wait_on_busy(&mut self) -> Result<(), SpiError<TSPIERR>> {
+        self.spi
+            .transaction(&mut [Operation::DelayNs(1000)])
+            .map_err(SpiError::Transfer)?;
+
+        while let Ok(true) = self.busy_pin.is_high() {
+            // NOP
+        }
+        Ok(())
+    }
+
+    /// Busily wait for the dio1 pin to go high
+    #[maybe_async_cfg::only_if(sync)]
+    fn wait_on_dio1(&mut self) -> Result<(), PinError<TPINERR>> {
+        while let Ok(true) = self.dio1_pin.is_low() {
+            // NOP
+        }
+        Ok(())
+    }
+
+    /// Busily wait for the busy pin to go low
+    #[maybe_async_cfg::only_if(async)]
+    pub async fn wait_on_busy(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
+        self.spi
+            .transaction(&mut [Operation::DelayNs(1000)])
+            .await
+            .map_err(SpiError::Transfer)?;
+
+        self.busy_pin
+            .wait_for_low()
+            .await
+            .map_err(PinError::Input)?;
+
+        Ok(())
+    }
+
+    /// Busily wait for the dio1 pin to go high
+    #[maybe_async_cfg::only_if(async)]
+    async fn wait_on_dio1(&mut self) -> Result<(), PinError<TPINERR>> {
+        self.dio1_pin
+            .wait_for_high()
+            .await
+            .map_err(PinError::Input)?;
+        Ok(())
+    }
+
     // Initialize and configure the SX126x using the provided Config
-    pub fn init(&mut self, conf: Config) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn init(&mut self, conf: Config) -> Result<(), SxError<TSPIERR, TPINERR>> {
         // Reset the sx
-        self.reset()?;
-        self.wait_on_busy()?;
+        self.reset().await?;
+        self.wait_on_busy().await?;
 
         // 1. If not in STDBY_RC mode, then go to this mode with the command SetStandby(...)
-        self.set_standby(crate::op::StandbyConfig::StbyRc)?;
-        self.wait_on_busy()?;
+        self.set_standby(crate::op::StandbyConfig::StbyRc).await?;
+        self.wait_on_busy().await?;
 
         // 2. Define the protocol (LoRa® or FSK) with the command SetPacketType(...)
-        self.set_packet_type(conf.packet_type)?;
-        self.wait_on_busy()?;
+        self.set_packet_type(conf.packet_type).await?;
+        self.wait_on_busy().await?;
 
         // 3. Define the RF frequency with the command SetRfFrequency(...)
-        self.set_rf_frequency(conf.rf_freq)?;
-        self.wait_on_busy()?;
+        self.set_rf_frequency(conf.rf_freq).await?;
+        self.wait_on_busy().await?;
 
         if let Some((tcxo_voltage, tcxo_delay)) = conf.tcxo_opts {
-            self.set_dio3_as_tcxo_ctrl(tcxo_voltage, tcxo_delay)?;
-            self.wait_on_busy()?;
+            self.set_dio3_as_tcxo_ctrl(tcxo_voltage, tcxo_delay).await?;
+            self.wait_on_busy().await?;
         }
 
         // Calibrate
-        self.calibrate(conf.calib_param)?;
-        self.wait_on_busy()?;
-        self.calibrate_image(CalibImageFreq::from_rf_frequency(conf.rf_frequency))?;
-        self.wait_on_busy()?;
+        self.calibrate(conf.calib_param).await?;
+        self.wait_on_busy().await?;
+        self.calibrate_image(CalibImageFreq::from_rf_frequency(conf.rf_frequency))
+            .await?;
+        self.wait_on_busy().await?;
 
         // 4. Define the Power Amplifier configuration with the command SetPaConfig(...)
-        self.set_pa_config(conf.pa_config)?;
-        self.wait_on_busy()?;
+        self.set_pa_config(conf.pa_config).await?;
+        self.wait_on_busy().await?;
 
         // 5. Define output power and ramping time with the command SetTxParams(...)
-        self.set_tx_params(conf.tx_params)?;
-        self.wait_on_busy()?;
+        self.set_tx_params(conf.tx_params).await?;
+        self.wait_on_busy().await?;
 
         // 6. Define where the data payload will be stored with the command SetBufferBaseAddress(...)
-        self.set_buffer_base_address(0x00, 0x00)?;
-        self.wait_on_busy()?;
+        self.set_buffer_base_address(0x00, 0x00).await?;
+        self.wait_on_busy().await?;
 
         // 7. Send the payload to the data buffer with the command WriteBuffer(...)
         // This is done later in SX126x::write_bytes
 
         // 8. Define the modulation parameter according to the chosen protocol with the command SetModulationParams(...) 1
-        self.set_mod_params(conf.mod_params)?;
-        self.wait_on_busy()?;
+        self.set_mod_params(conf.mod_params).await?;
+        self.wait_on_busy().await?;
 
         // 9. Define the frame format to be used with the command SetPacketParams(...) 2
         if let Some(packet_params) = conf.packet_params {
-            self.set_packet_params(packet_params)?;
-            self.wait_on_busy()?;
+            self.set_packet_params(packet_params).await?;
+            self.wait_on_busy().await?;
         }
 
         // 10. Configure DIO and IRQ: use the command SetDioIrqParams(...) to select TxDone IRQ and map this IRQ to a DIO (DIO1,
@@ -120,14 +182,15 @@ where
             conf.dio1_irq_mask,
             conf.dio2_irq_mask,
             conf.dio3_irq_mask,
-        )?;
-        self.wait_on_busy()?;
-        self.set_dio2_as_rf_switch_ctrl(true)?;
-        self.wait_on_busy()?;
+        )
+        .await?;
+        self.wait_on_busy().await?;
+        self.set_dio2_as_rf_switch_ctrl(true).await?;
+        self.wait_on_busy().await?;
 
         // 11. Define Sync Word value: use the command WriteReg(...) to write the value of the register via direct register access
-        self.set_sync_word(conf.sync_word)?;
-        self.wait_on_busy()?;
+        self.set_sync_word(conf.sync_word).await?;
+        self.wait_on_busy().await?;
 
         // The rest of the steps are done by the user
         Ok(())
@@ -136,84 +199,91 @@ where
     /// Set the LoRa Sync word
     /// Use 0x3444 for public networks like TTN
     /// Use 0x1424 for private networks
-    pub fn set_sync_word(&mut self, sync_word: u16) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn set_sync_word(&mut self, sync_word: u16) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.write_register(Register::LoRaSyncWordMsb, &sync_word.to_be_bytes())
+            .await
     }
 
     /// Set the modem packet type, which can be either GFSK of LoRa
     /// Note: GFSK is not fully supported by this crate at the moment
-    pub fn set_packet_type(
+    pub async fn set_packet_type(
         &mut self,
         packet_type: PacketType,
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x8A, packet_type as u8])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Put the modem in standby mode
-    pub fn set_standby(
+    pub async fn set_standby(
         &mut self,
-
         standby_config: StandbyConfig,
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x80, standby_config as u8])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Get the current status of the modem
-    pub fn get_status(&mut self) -> Result<Status, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_status(&mut self) -> Result<Status, SxError<TSPIERR, TPINERR>> {
         let mut result = [0xC0, NOP];
         self.spi
             .transfer_in_place(&mut result)
+            .await
             .map_err(SpiError::Transfer)?;
 
         Ok(result[1].into())
     }
 
-    pub fn set_fs(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
-        self.spi.write(&[0xC1]).map_err(SpiError::Write)?;
+    pub async fn set_fs(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
+        self.spi.write(&[0xC1]).await.map_err(SpiError::Write)?;
         Ok(())
     }
 
-    pub fn get_stats(&mut self) -> Result<Stats, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_stats(&mut self) -> Result<Stats, SxError<TSPIERR, TPINERR>> {
         let mut result = [0x10, NOP, NOP, NOP, NOP, NOP, NOP, NOP];
         self.spi
             .transfer_in_place(&mut result)
+            .await
             .map_err(SpiError::Transfer)?;
 
         Ok(TryInto::<[u8; 7]>::try_into(&result[1..]).unwrap().into())
     }
 
     /// Calibrate image
-    pub fn calibrate_image(
+    pub async fn calibrate_image(
         &mut self,
-
         freq: CalibImageFreq,
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let freq: [u8; 2] = freq.into();
         let mut ops = [Operation::Write(&[0x98]), Operation::Write(&freq)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Calibrate modem
-    pub fn calibrate(&mut self, calib_param: CalibParam) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn calibrate(
+        &mut self,
+        calib_param: CalibParam,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x89, calib_param.into()])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Write data into a register
-    pub fn write_register(
+    pub async fn write_register(
         &mut self,
-
         register: Register,
         data: &[u8],
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
@@ -224,14 +294,16 @@ where
             Operation::Write(data),
         ];
 
-        self.spi.transaction(&mut ops).map_err(SpiError::Write)?;
+        self.spi
+            .transaction(&mut ops)
+            .await
+            .map_err(SpiError::Write)?;
         Ok(())
     }
 
     /// Read data from a register
-    pub fn read_register(
+    pub async fn read_register(
         &mut self,
-
         start_addr: u16,
         result: &mut [u8],
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
@@ -244,14 +316,16 @@ where
             Operation::Read(result),
         ];
 
-        self.spi.transaction(&mut ops).map_err(SpiError::Transfer)?;
+        self.spi
+            .transaction(&mut ops)
+            .await
+            .map_err(SpiError::Transfer)?;
         Ok(())
     }
 
     /// Write data into the buffer at the defined offset
-    pub fn write_buffer(
+    pub async fn write_buffer(
         &mut self,
-
         offset: u8,
         data: &[u8],
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
@@ -259,14 +333,14 @@ where
         let mut ops = [Operation::Write(&header), Operation::Write(data)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Read data from the data from the defined offset
-    pub fn read_buffer(
+    pub async fn read_buffer(
         &mut self,
-
         offset: u8,
         result: &mut [u8],
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
@@ -274,35 +348,38 @@ where
         let mut ops = [Operation::Write(&header), Operation::Read(result)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Transfer)
             .map_err(Into::into)
     }
 
     /// Configure the dio2 pin as RF control switch
-    pub fn set_dio2_as_rf_switch_ctrl(
+    pub async fn set_dio2_as_rf_switch_ctrl(
         &mut self,
-
         enable: bool,
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x9D, enable as u8])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
-    pub fn get_packet_status(&mut self) -> Result<PacketStatus, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_packet_status(&mut self) -> Result<PacketStatus, SxError<TSPIERR, TPINERR>> {
         let header = [0x14, NOP];
         let mut result = [NOP; 3];
         let mut ops = [Operation::Write(&header), Operation::Read(&mut result)];
-        self.spi.transaction(&mut ops).map_err(SpiError::Transfer)?;
+        self.spi
+            .transaction(&mut ops)
+            .await
+            .map_err(SpiError::Transfer)?;
 
         Ok(result.into())
     }
 
     /// Configure the dio3 pin as TCXO control switch
-    pub fn set_dio3_as_tcxo_ctrl(
+    pub async fn set_dio3_as_tcxo_ctrl(
         &mut self,
-
         tcxo_voltage: TcxoVoltage,
         tcxo_delay: TcxoDelay,
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
@@ -311,23 +388,26 @@ where
         let mut ops = [Operation::Write(&header), Operation::Write(&tcxo_delay)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Clear device error register
-    pub fn clear_device_errors(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn clear_device_errors(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x07, NOP, NOP])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Get current device errors
-    pub fn get_device_errors(&mut self) -> Result<DeviceErrors, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_device_errors(&mut self) -> Result<DeviceErrors, SxError<TSPIERR, TPINERR>> {
         let mut result = [0x17, NOP, NOP, NOP];
         self.spi
             .transfer_in_place(&mut result)
+            .await
             .map_err(SpiError::Transfer)?;
         Ok(DeviceErrors::from(u16::from_le_bytes(
             result[2..].try_into().unwrap(),
@@ -335,22 +415,21 @@ where
     }
 
     /// Reset the device py pulling nrst low for a while
-    pub fn reset(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
-        critical_section::with(|_| {
-            self.nrst_pin.set_low().map_err(PinError::Output)?;
-            // 8.1: The pin should be held low for typically 100 μs for the Reset to happen
-            self.spi
-                .transaction(&mut [Operation::DelayNs(200_000)])
-                .map_err(SpiError::Write)?;
-            self.nrst_pin
-                .set_high()
-                .map_err(PinError::Output)
-                .map_err(Into::into)
-        })
+    pub async fn reset(&mut self) -> Result<(), SxError<TSPIERR, TPINERR>> {
+        self.nrst_pin.set_low().map_err(PinError::Output)?;
+        // 8.1: The pin should be held low for typically 100 μs for the Reset to happen
+        self.spi
+            .transaction(&mut [Operation::DelayNs(200_000)])
+            .await
+            .map_err(SpiError::Write)?;
+        self.nrst_pin
+            .set_high()
+            .map_err(PinError::Output)
+            .map_err(Into::into)
     }
 
     /// Enable antenna
-    pub fn set_ant_enabled(&mut self, enabled: bool) -> Result<(), TPINERR> {
+    pub async fn set_ant_enabled(&mut self, enabled: bool) -> Result<(), TPINERR> {
         if enabled {
             self.ant_pin.set_high()
         } else {
@@ -359,7 +438,7 @@ where
     }
 
     /// Configure IRQ
-    pub fn set_dio_irq_params(
+    pub async fn set_dio_irq_params(
         &mut self,
 
         irq_mask: IrqMask,
@@ -380,53 +459,68 @@ where
         ];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Transfer)
             .map_err(Into::into)
     }
 
     /// Get the current IRQ status
-    pub fn get_irq_status(&mut self) -> Result<IrqStatus, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_irq_status(&mut self) -> Result<IrqStatus, SxError<TSPIERR, TPINERR>> {
         let mut status = [NOP, NOP, NOP];
         let mut ops = [Operation::Write(&[0x12]), Operation::Read(&mut status)];
-        self.spi.transaction(&mut ops).map_err(SpiError::Transfer)?;
+        self.spi
+            .transaction(&mut ops)
+            .await
+            .map_err(SpiError::Transfer)?;
         let irq_status: [u8; 2] = [status[1], status[2]];
         Ok(u16::from_be_bytes(irq_status).into())
     }
 
     /// Clear the IRQ status
-    pub fn clear_irq_status(&mut self, mask: IrqMask) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn clear_irq_status(
+        &mut self,
+        mask: IrqMask,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let mask = Into::<u16>::into(mask).to_be_bytes();
         let mut ops = [Operation::Write(&[0x02]), Operation::Write(&mask)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Put the device in TX mode. It will start sending the data written in the buffer,
     /// starting at the configured offset
-    pub fn set_tx(&mut self, timeout: RxTxTimeout) -> Result<Status, SxError<TSPIERR, TPINERR>> {
+    pub async fn set_tx(
+        &mut self,
+        timeout: RxTxTimeout,
+    ) -> Result<Status, SxError<TSPIERR, TPINERR>> {
         let mut buf = [0x83u8; 4];
         let timeout: [u8; 3] = timeout.into();
         buf[1..].copy_from_slice(&timeout);
 
         self.spi
             .transfer_in_place(&mut buf)
+            .await
             .map_err(SpiError::Transfer)?;
         Ok(timeout[1].into())
     }
 
-    pub fn set_rx(&mut self, timeout: RxTxTimeout) -> Result<Status, SxError<TSPIERR, TPINERR>> {
+    pub async fn set_rx(
+        &mut self,
+        timeout: RxTxTimeout,
+    ) -> Result<Status, SxError<TSPIERR, TPINERR>> {
         let mut buf = [0x82u8; 4];
         let timeout: [u8; 3] = timeout.into();
         buf[1..].copy_from_slice(&timeout);
 
-        self.spi.write(&buf).map_err(SpiError::Transfer)?;
+        self.spi.write(&buf).await.map_err(SpiError::Transfer)?;
         Ok(timeout[0].into())
     }
 
     /// Set packet parameters
-    pub fn set_packet_params(
+    pub async fn set_packet_params(
         &mut self,
 
         params: PacketParams,
@@ -435,26 +529,35 @@ where
         let mut ops = [Operation::Write(&[0x8C]), Operation::Write(&params)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Set modulation parameters
-    pub fn set_mod_params(&mut self, params: ModParams) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn set_mod_params(
+        &mut self,
+        params: ModParams,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let params: [u8; 8] = params.into();
         let mut ops = [Operation::Write(&[0x8B]), Operation::Write(&params)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Set TX parameters
-    pub fn set_tx_params(&mut self, params: TxParams) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn set_tx_params(
+        &mut self,
+        params: TxParams,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let params: [u8; 2] = params.into();
         let mut ops = [Operation::Write(&[0x8E]), Operation::Write(&params)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
@@ -462,27 +565,35 @@ where
     /// Set RF frequency. This writes the passed rf_freq directly to the modem.
     /// Use sx1262::calc_rf_freq to calulate the correct value based
     /// On the XTAL frequency and the desired RF frequency
-    pub fn set_rf_frequency(&mut self, rf_freq: u32) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn set_rf_frequency(
+        &mut self,
+        rf_freq: u32,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let rf_freq = rf_freq.to_be_bytes();
         let mut ops = [Operation::Write(&[0x86]), Operation::Write(&rf_freq)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Set Power Amplifier configuration
-    pub fn set_pa_config(&mut self, pa_config: PaConfig) -> Result<(), SxError<TSPIERR, TPINERR>> {
+    pub async fn set_pa_config(
+        &mut self,
+        pa_config: PaConfig,
+    ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         let pa_config: [u8; 4] = pa_config.into();
         let mut ops = [Operation::Write(&[0x95]), Operation::Write(&pa_config)];
         self.spi
             .transaction(&mut ops)
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
 
     /// Configure the base addresses in the buffer
-    pub fn set_buffer_base_address(
+    pub async fn set_buffer_base_address(
         &mut self,
 
         tx_base_addr: u8,
@@ -490,6 +601,7 @@ where
     ) -> Result<(), SxError<TSPIERR, TPINERR>> {
         self.spi
             .write(&[0x8F, tx_base_addr, rx_base_addr])
+            .await
             .map_err(SpiError::Write)
             .map_err(Into::into)
     }
@@ -498,7 +610,7 @@ where
     /// puts the device in TX mode, and waits until the devices
     /// is done sending the data or a timeout occurs.
     /// Please note that this method updates the packet params
-    pub fn write_bytes(
+    pub async fn write_bytes(
         &mut self,
         data: &[u8],
         timeout: RxTxTimeout,
@@ -507,7 +619,7 @@ where
     ) -> Result<Status, SxError<TSPIERR, TPINERR>> {
         use packet::LoRaPacketParams;
         // Write data to buffer
-        self.write_buffer(0x00, data)?;
+        self.write_buffer(0x00, data).await?;
 
         // Set packet params
         let params = LoRaPacketParams::default()
@@ -516,46 +628,30 @@ where
             .set_crc_type(crc_type)
             .into();
 
-        self.set_packet_params(params)?;
+        self.set_packet_params(params).await?;
 
         // Set tx mode
-        let status = self.set_tx(timeout)?;
+        let status = self.set_tx(timeout).await?;
         // Wait for busy line to go low
-        self.wait_on_busy().map_err(SxError::Spi)?;
+        self.wait_on_busy().await?;
         // Wait on dio1 going high
-        self.wait_on_dio1()?;
+        self.wait_on_dio1().await?;
         // Clear IRQ
-        self.clear_irq_status(IrqMask::all())?;
+        self.clear_irq_status(IrqMask::all()).await?;
         // Write completed!
         Ok(status)
     }
 
     /// Get Rx buffer status, containing the length of the last received packet
     /// and the address of the first byte received.
-    pub fn get_rx_buffer_status(&mut self) -> Result<RxBufferStatus, SxError<TSPIERR, TPINERR>> {
+    pub async fn get_rx_buffer_status(
+        &mut self,
+    ) -> Result<RxBufferStatus, SxError<TSPIERR, TPINERR>> {
         let mut result = [0x13, NOP, NOP, NOP];
         self.spi
             .transfer_in_place(&mut result)
+            .await
             .map_err(SpiError::Transfer)?;
         Ok(TryInto::<[u8; 2]>::try_into(&result[2..]).unwrap().into())
-    }
-
-    /// Busily wait for the busy pin to go low
-    pub fn wait_on_busy(&mut self) -> Result<(), SpiError<TSPIERR>> {
-        self.spi
-            .transaction(&mut [Operation::DelayNs(1000)])
-            .map_err(SpiError::Transfer)?;
-        while let Ok(true) = self.busy_pin.is_high() {
-            // NOP
-        }
-        Ok(())
-    }
-
-    /// Busily wait for the dio1 pin to go high
-    fn wait_on_dio1(&mut self) -> Result<(), PinError<TPINERR>> {
-        while let Ok(true) = self.dio1_pin.is_low() {
-            // NOP
-        }
-        Ok(())
     }
 }


### PR DESCRIPTION
Alternate proposal to #8 that avoids duplicating code. Adds an optional "async" feature that, if enabled, adds an `SX126xAsync` struct that uses the `embedded_hal_async::spi`  and `embedded_hal_async::digital::Wait` traits for the I/O interface.